### PR TITLE
Pull in title from Sites framework

### DIFF
--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -1,0 +1,17 @@
+from django.conf import settings as django_settings
+
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+
+def current_site(request):
+    '''
+    A context processor to add the "current site" to the current Context
+    '''
+    try:
+        current_site = Site.objects.get_current()
+        return {
+            'current_site': current_site,
+        }
+    except Site.DoesNotExist:
+        return {'current_site': 'Encampment Tracker'}

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -77,6 +77,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "config.context_processors.current_site",
             ],
         },
     },
@@ -155,7 +156,8 @@ SOCIALACCOUNT_PROVIDERS = {
 
 STRONGHOLD_PUBLIC_URLS = (r"^/accounts/.+$",)
 
-# Local options
-LOCAL_CITY = "Oakland, CA"  # Used to focus geocoding requests
-LOCAL_LONGITUDE = -122.271  # Used to focus geocoding requests
-LOCAL_LATITUDE = 37.804  # Used to focus geocoding requests
+### Local options
+# Used to focus geocoding requests
+LOCAL_CITY = os.environ.get("LOCAL_CITY", "Oakland, CA")  
+LOCAL_LONGITUDE = float(os.environ.get("LOCAL_LONGITUDE", "-122.271"))
+LOCAL_LATITUDE = float(os.environ.get("LOCAL_LATITUDE", "37.804"))

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Encampment Tracker</title>
+    <title>{{current_site.name}}</title>
 </head>
 <body class="{% block bodyclass %}{% endblock %}">
 
@@ -506,7 +506,7 @@ body.dashboard .container {
 <div class="shell">
   <header class="shell-header">
     <div class="shell-header-start">
-      <h1><a href="{% url 'encampment-list' %}">ENCAMPMENT TRACKER</a></h1>
+      <h1><a href="{% url 'encampment-list' %}">{{current_site.name.upper}}</a></h1>
     </div>
 
     <nav class="inlinenav">


### PR DESCRIPTION
Adds a context processor so you can `{{current_site.name.upper}}` in templates:

<img width="539" alt="Screen Shot 2020-05-28 at 9 16 26 PM" src="https://user-images.githubusercontent.com/69848/83210302-7f9d4b00-a128-11ea-84e5-d61e904803d7.png">
<img width="594" alt="Screen Shot 2020-05-28 at 9 16 38 PM" src="https://user-images.githubusercontent.com/69848/83210313-875cef80-a128-11ea-98d2-b34c980bd44c.png">
