### PR TITLE
encampment list mobile

### DIFF
--- a/apps/reporting/templates/reporting/encampment_list.html
+++ b/apps/reporting/templates/reporting/encampment_list.html
@@ -15,7 +15,7 @@
         <!-- TODO: context aware coloring -->
         <div class="infonugget-icon orange">{% svg 'tick' %}</div>
         <div class="infonugget-stat">{{ pending_tasks }}</div>
-        <div class="infonugget-description">tasks pending</div>
+        <div class="infonugget-description">tasks<br> pending</div>
     </div>
 <div class="infonugget">
   <div class="infonugget-icon grey">{% svg 'calendar' %}</div>
@@ -28,7 +28,7 @@
   <div class="infonugget-description">visits in last<br> 31 days</div>
 </div>
 </div>
-<div class="container">
+<div class="container layout-split">
     <ul class="table-nav">
       <li class="{% if nav_context == '' %}active{% endif %}"><a href="{% url 'encampment-list' %}">All Encampments</a></li>
       <li class="{% if nav_context == delayed %}active{% endif %}"><a href="{% url 'encampment-list-filtered' 'delayed' %}">Not Visited <span class="nav-count">3</span></a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,6 +63,10 @@ body {
   padding: 20px;
 }
 
+.layout-split {
+  display: block;
+}
+
 @media (min-width: 600px) {
   .show-on-desktop {
     display:unset;
@@ -70,6 +74,10 @@ body {
 
   .container {
     padding: 30px;
+  }
+
+  .layout-split {
+    display:flex;
   }
 }
 
@@ -242,44 +250,59 @@ body {
 }
 
 
+
 /* ================================
    Data Table
 */
 
-body.dashboard .container {
-  display: flex;
-}
 
-.table-nav {
-  min-width: 180px;
-  list-style-type: none;
-  padding: 0;
-  border-right: 1px solid #ccc;
-  padding-top: 35px;
-  font-weight: 300;
-  text-align: right;
-  margin-right: 40px;
-}
-.table-nav li {
-  padding-right: 40px;
-  margin-bottom: 20px;
-}
-.table-nav a { color: #888; }
-.table-nav a:hover { color: #333; }
-.table-nav .active {
-  border-right: 5px solid #063;
-}
-.table-nav li.active a { color: #333; }
-.table-nav li.active a:hover { color: #888; }
-.table-nav .nav-count {
-  display: inline-block;
-  border-radius: 20px;
-  background: #888;
-  color: #fff;
-  font-size: 10px;
-  padding: 3px 6px;
-  vertical-align: bottom;
-  margin-left: 5px;
+  .table-nav {
+    display:flex;
+    flex-wrap: wrap;
+    padding: 0;
+    list-style-type: none;
+  }
+  .table-nav a {
+    display: inline-block;
+    padding: 10px 20px;
+    color: #888;
+  }
+  .table-nav a:hover { color: #333; }
+  .table-nav li.active a { color: #333; }
+
+
+@media (min-width: 600px) {
+  .table-nav {
+    display: initial;
+    min-width: 180px;
+    border-right: 1px solid #ccc;
+    padding-top: 35px;
+    font-weight: 300;
+    text-align: right;
+    margin-right: 40px;
+  }
+  .table-nav li {
+    padding-right: 40px;
+    margin-bottom: 20px;
+  }
+  .table-nav a {
+    display: initial;
+    padding: initial;
+  }
+  .table-nav .active {
+    border-right: 5px solid #063;
+  }
+  .table-nav li.active a:hover { color: #888; }
+  .table-nav .nav-count {
+    display: inline-block;
+    border-radius: 20px;
+    background: #888;
+    color: #fff;
+    font-size: 10px;
+    padding: 3px 6px;
+    vertical-align: bottom;
+    margin-left: 5px;
+  }
 }
 
 .datatable { width: 100%; }


### PR DESCRIPTION
Currently have the list displayed in an inline list on mobile. Mostly to handle scenarios like a tablet where someone may end up switching between mobile and desktop views. If the list is filtered and they switch to mobile, they'd have no way to switch back unless they switch views back. I thought that might be confusing. 

<img width="533" alt="Screen Shot 2020-05-29 at 12 13 47 AM" src="https://user-images.githubusercontent.com/12890/83220538-46250980-a141-11ea-99e9-f2c33c16c318.png">
