### PR TITLE
add viewport meta tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{current_site.name}}</title>
 </head>
 <body class="{% block bodyclass %}{% endblock %}">


### PR DESCRIPTION
sets viewport tag so mobile devices won't pretend it's a desktop site.