### PR TITLE
Fixed field-label on desktop

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -424,7 +424,7 @@ body {
         border-top: 0;
       }
 
-     .field > label {
+     .field > label, .field-label {
        flex-basis: 200px;
        flex-shrink: 0;
      }


### PR DESCRIPTION
What it looks like on desktop: 
<img width="378" alt="Screen Shot 2020-05-29 at 11 19 57 AM" src="https://user-images.githubusercontent.com/12890/83276263-57503380-a19e-11ea-8e91-6e858c58d725.png">
