### PR TITLE
fix broken layout

### DIFF
--- a/apps/reporting/templates/reporting/encampment_detail.html
+++ b/apps/reporting/templates/reporting/encampment_detail.html
@@ -141,9 +141,12 @@
                     <div class="spacer"></div>
                     <div class="performed-by">{{ visit.performed_by }}</div>
                 </div>
-                {% endfor %}
             </div>
+            {% endfor %}
         </div>
+    </div>
+    <!-- end visits panel -->
+
         <div class="tasks">
             <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
 


### PR DESCRIPTION
Made sure elements close off properly to prevent layout from breaking. (this PR makes sure that tasks show up in the right column; it doesn't address the list view itself.)

<img width="1106" alt="Screen Shot 2020-06-02 at 11 17 31 AM" src="https://user-images.githubusercontent.com/12890/83537526-a8279b00-a4c2-11ea-8b08-4e69eae032c2.png">
