### PR TITLE
Add /visits/cal.ics calendar feed

### DIFF
--- a/apps/reporting/serializers.py
+++ b/apps/reporting/serializers.py
@@ -30,7 +30,7 @@ class ReportSerializer(serializers.ModelSerializer):
 class OrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organization
-        fields = ["name"]
+        fields = ["name", "id"]
 
 
 class EncampmentSerializer(serializers.ModelSerializer):

--- a/apps/reporting/urls.py
+++ b/apps/reporting/urls.py
@@ -1,19 +1,10 @@
-from django.urls import include
 from django.urls import path
-from rest_framework.routers import DefaultRouter
 
 from apps.reporting import views
 
 # Create a router and register our viewsets with it.
 
-router = DefaultRouter()
-router.register(r"visits", views.ReportViewSet)
-router.register(r"organizations", views.OrganizationViewSet)
-router.register(r"encampments", views.EncampmentViewSet)
-
 urlpatterns = [
-    # API
-    path("api/", include(router.urls)),
     # Encampments
     path("", views.EncampmentListView.as_view(), name="encampment-list"),
     path(
@@ -37,4 +28,5 @@ urlpatterns = [
     path("tasks/<str:pk>/complete", views.CompleteTask.as_view(), name="task-complete"),
     # Visits
     path("visits/", views.ScheduleVisitCreateView.as_view(), name="visit-create"),
+    path("visits/cal.ics", views.ScheduledVisitEventFeed()),
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,28 +1,9 @@
-from django.conf.urls import url
 from django.contrib import admin
 from django.urls import include
 from django.urls import path
-from django.views.generic import TemplateView
-from rest_framework.schemas import get_schema_view
 
 urlpatterns = [
     path("", include("apps.reporting.urls")),
     path("admax/", admin.site.urls),
     path("accounts/", include("allauth.urls")),
-    url(r"^api-auth/", include("rest_framework.urls")),
-    path(
-        "openapi",
-        get_schema_view(
-            title="Your Project", description="API for all things …", version="1.0.0"
-        ),
-        name="openapi-schema",
-    ),
-    path(
-        "swagger-ui/",
-        TemplateView.as_view(
-            template_name="swagger-ui.html",
-            extra_context={"schema_url": "openapi-schema"},
-        ),
-        name="swagger-ui",
-    ),
 ]

--- a/reqs/common.base
+++ b/reqs/common.base
@@ -12,3 +12,4 @@ django-allauth==0.42.0
 django-stronghold>=0.4.0,<0.5
 django-inline-svg>=0.1.1,<0.2
 humanize>=2.4.0,<2.5
+django-ical>=1.7.1,<1.8

--- a/reqs/dev.txt
+++ b/reqs/dev.txt
@@ -24,7 +24,9 @@ django-allauth==0.42.0
 django-extensions==2.2.9
 django-extra-fields==2.0.5
 django-filter==2.2.0
+django-ical==1.7.1
 django-inline-svg==0.1.1
+django-recurrence==1.10.3
 django-stronghold==0.4.0
 django-tables2==2.3.1
 django==3.0.6
@@ -41,6 +43,7 @@ flake8-quotes==3.0.0
 flake8==3.7.9
 freezegun==0.3.15
 humanize==2.4.0
+icalendar==4.0.6
 idna==2.9
 ipython-genutils==0.2.0
 ipython==7.14.0

--- a/reqs/prod.txt
+++ b/reqs/prod.txt
@@ -16,7 +16,9 @@ dj-database-url==0.5.0
 django-allauth==0.42.0
 django-extra-fields==2.0.5
 django-filter==2.2.0
+django-ical==1.7.1
 django-inline-svg==0.1.1
+django-recurrence==1.10.3
 django-stronghold==0.4.0
 django-tables2==2.3.1
 django==3.0.6
@@ -24,6 +26,7 @@ djangorestframework==3.11.0
 docutils==0.15.2
 gunicorn==20.0.4
 humanize==2.4.0
+icalendar==4.0.6
 idna==2.9
 iso3166==1.0.1
 jmespath==0.10.0


### PR DESCRIPTION
By default, it returns a calendar for all visits. It is also filterable by organization via `/visits/cal.ics?organization=<org_uuid>`

Separately, we'll need to link to both of these things from the appropriate place.
<img width="535" alt="Screenshot 2020-06-18 11 37 28" src="https://user-images.githubusercontent.com/492903/85041627-3903a500-b158-11ea-973b-58e8da6c7f2b.png">

Eventually, we'll probably want richer events with locations etc. but punting on that for now.

For local testing, you can subscribe Calendar to `http://localhost:8000/visits/cal.ics`

Currently, it's public, we might want to generate some sort of signed url for it eventually just to make it slightly more secure, but the URL needs to be at least mostly-public for external apps to download it.

Fixes #32 
Fixes #33 